### PR TITLE
First sketch of the cache backend.

### DIFF
--- a/modules/rethinkdb_cache/rethinkdb_cache.routing.yml
+++ b/modules/rethinkdb_cache/rethinkdb_cache.routing.yml
@@ -1,5 +1,5 @@
 rethinkdb_cache.ab_testing_hello:
-  path: '/rethinkdb_cache/ab_testing/{database}/{operation}'
+  path: '/rethinkdb_cache/ab_testing/{database}/{operation}/{items}'
   defaults:
     _controller: '\Drupal\rethinkdb_cache\Controller\AbTesting::AbTestingController'
     _title: 'AbTesting'

--- a/modules/rethinkdb_cache/rethinkdb_cache.services.yml
+++ b/modules/rethinkdb_cache/rethinkdb_cache.services.yml
@@ -2,3 +2,9 @@ services:
   rethinkdb_cache:
     class: Drupal\rethinkdb_cache\RethinkDBCache
     arguments: ['@rethinkdb', '@cache_tags.invalidator.checksum']
+  cache.backend.rethinkdb:
+    class: Drupal\rethinkdb_cache\Cache\RethinkDBCacheBackendFactory
+    arguments: ['@rethinkdb_cache', '@cache_tags.invalidator.checksum']
+  cache.backend.rethinkdb.entity:
+    class: Drupal\rethinkdb_cache\Cache\RethinkDBEntityCache
+    arguments: ['@rethinkdb_cache', '@cache_tags.invalidator.checksum']

--- a/modules/rethinkdb_cache/src/Cache/RethinkDBCacheBackendFactory.php
+++ b/modules/rethinkdb_cache/src/Cache/RethinkDBCacheBackendFactory.php
@@ -1,0 +1,65 @@
+<?php
+
+/**
+ * @file
+ * Contains \Drupal\rethinkdb_cache\Cache\CacheBackendFactory.
+ */
+
+namespace Drupal\rethinkdb_cache\Cache;
+
+use Drupal\Core\Cache\CacheFactoryInterface;
+use Drupal\Core\Cache\CacheTagsChecksumInterface;
+use Drupal\rethinkdb_cache\RethinkDBCache;
+
+/**
+ * A generic cache factory based on RethinkDB cache.
+ */
+class RethinkDBCacheBackendFactory implements CacheFactoryInterface {
+
+  /**
+   * @var \Drupal\rethinkdb_cache\RethinkDBCache
+   */
+  protected $clientFactory;
+
+  /**
+   * The cache tags checksum provider.
+   *
+   * @var \Drupal\Core\Cache\CacheTagsChecksumInterface
+   */
+  protected $checksumProvider;
+
+  /**
+   * List of cache bins.
+   *
+   * Renderer and possibly other places fetch backends directly from the
+   * factory. Avoid that the backend objects have to fetch meta information like
+   * the last delete all timestamp multiple times.
+   *
+   * @var array
+   */
+  protected $bins = [];
+
+  /**
+   * Creates a rethinkdb cache CacheBackendFactory.
+   *
+   * @param RethinkDBCache $client_factory
+   * @param CacheTagsChecksumInterface $checksum_provider
+   */
+  function __construct(RethinkDBCache $client_factory, CacheTagsChecksumInterface $checksum_provider) {
+    $this->clientFactory = $client_factory;
+    $this->checksumProvider = $checksum_provider;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function get($bin) {
+    $cache = clone $this->clientFactory;
+
+    // todo: create the table bin.
+    $cache->setTableName($bin);
+
+    return $cache;
+  }
+
+}

--- a/modules/rethinkdb_cache/src/Cache/RethinkDBEntityCache.php
+++ b/modules/rethinkdb_cache/src/Cache/RethinkDBEntityCache.php
@@ -1,0 +1,31 @@
+<?php
+
+/**
+ * @file
+ * Contains \Drupal\rethinkdb_cache\Cache\CacheBackendFactory.
+ */
+
+namespace Drupal\rethinkdb_cache\Cache;
+
+use Drupal\Core\Cache\CacheFactoryInterface;
+use Drupal\Core\Cache\CacheTagsChecksumInterface;
+use Drupal\rethinkdb_cache\RethinkDBCache;
+
+/**
+ * A generic cache factory based on RethinkDB cache.
+ */
+class RethinkDBEntityCache extends RethinkDBCacheBackendFactory {
+
+  /**
+   * {@inheritdoc}
+   */
+  public function get($bin) {
+    $cache = clone $this->clientFactory;
+
+    // todo: create the table bin.
+    $cache->setTableName('entity_cache');
+
+    return $cache;
+  }
+
+}

--- a/modules/rethinkdb_cache/src/Controller/AbTesting.php
+++ b/modules/rethinkdb_cache/src/Controller/AbTesting.php
@@ -23,25 +23,29 @@ class AbTesting extends ControllerBase {
    * @return string
    *   The amount of duration for the operation.
    */
-  public function AbTestingController($database, $operation) {
+  public function AbTestingController($database, $operation, $items) {
 
     $cache = $database == 'rethinkdb' ? \Drupal::service('rethinkdb_cache') : \Drupal::cache();
     $time_start = microtime(true);
 
     if ($operation == 'write') {
-      for ($i = 0; $i <= 1000; $i++) {
+      for ($i = 0; $i <= $items; $i++) {
         $cache->set('testing' . $i, time());
       }
     }
     else {
 
-      for ($i = 0; $i <= 1000; $i++) {
-        $cache->get('testing' . $i);
+      $caches = [];
+      for ($i = 0; $i <= $items; $i++) {
+        $caches[] = 'testing' . $i;
       }
+
+      $foo = $cache->getMultiple($caches);
     }
 
     $time_end = microtime(true);
     $time = $time_end - $time_start;
+    dpm(count($foo));
 
     $params = [
       '@time' => $time,

--- a/modules/rethinkdb_cache/src/Controller/AbTesting.php
+++ b/modules/rethinkdb_cache/src/Controller/AbTesting.php
@@ -34,13 +34,10 @@ class AbTesting extends ControllerBase {
       }
     }
     else {
-      $cids = [];
 
       for ($i = 0; $i <= 1000; $i++) {
-        $cids[] = 'testing' . $i;
+        $cache->get('testing' . $i);
       }
-
-      $cache->getMultiple($cids);
     }
 
     $time_end = microtime(true);

--- a/modules/rethinkdb_cache/src/RethinkDBCache.php
+++ b/modules/rethinkdb_cache/src/RethinkDBCache.php
@@ -72,6 +72,30 @@ class RethinkDBCache implements CacheBackendInterface {
   }
 
   /**
+   * Get the table name.
+   *
+   * @return string
+   *   The table name.
+   */
+  public function getTableName() {
+    return $this->table_name;
+  }
+
+  /**
+   * Set the table name.
+   *
+   * @param string $table_name
+   *   The table name.
+   *
+   * @return \Drupal\rethinkdb_cache\RethinkDBCache
+   */
+  public function setTableName($table_name) {
+    $this->table_name = $table_name;
+    $this->table = $this->rethinkdb->getTable($this->table_name);
+    return $this;
+  }
+
+  /**
    * {@inheritdoc}
    */
   public function get($cid, $allow_invalid = FALSE) {
@@ -100,6 +124,7 @@ class RethinkDBCache implements CacheBackendInterface {
         continue;
       }
 
+      $document->data = unserialize($document->data);
       $caches[$document->cid] = $document;
     }
 
@@ -151,6 +176,8 @@ class RethinkDBCache implements CacheBackendInterface {
    */
   public function set($cid, $data, $expire = Cache::PERMANENT, array $tags = array()) {
 
+    $cid = str_replace(['"', '\\'], "_", $cid);
+    $data = serialize($data);
     $checksum = $this->checksumProvider->getCurrentChecksum($tags);
 
     if ($stored = $this->get($cid)) {
@@ -268,4 +295,5 @@ class RethinkDBCache implements CacheBackendInterface {
     $this->rethinkdb->tableCreate($this->table_name);
     $this->rethinkdb->createIndex($this->table_name, 'cid');
   }
+
 }

--- a/modules/rethinkdb_cache/src/RethinkDBCache.php
+++ b/modules/rethinkdb_cache/src/RethinkDBCache.php
@@ -99,9 +99,18 @@ class RethinkDBCache implements CacheBackendInterface {
    * {@inheritdoc}
    */
   public function get($cid, $allow_invalid = FALSE) {
-    $cids = array($cid);
-    $data = $this->getMultiple($cids, $allow_invalid);
-    return reset($data);
+    $data = &drupal_static('foo' . $cid);
+
+    if (!$data) {
+      $cids = array($cid);
+      $data = $this->getMultiple($cids, $allow_invalid);
+      $value = reset($data);
+      $data[$cid] = $value;
+      return $value;
+    }
+    else {
+      return $data;
+    }
   }
 
   /**

--- a/src/RethinkDB.php
+++ b/src/RethinkDB.php
@@ -44,6 +44,9 @@ class RethinkDB {
    * @param ConfigFactoryInterface $config_factory
    */
   public function __construct(ConfigFactoryInterface $config_factory) {
+    if ($this->getConnection()) {
+      return;
+    }
 
     $config = $config_factory->get('rethinkdb.database');
 


### PR DESCRIPTION
#30

Add this to the settings.php file:
`$settings['cache']['bins']['entity'] = 'cache.backend.rethinkdb.entity';`

The goal is to get 560ms when viewing a simple node.
